### PR TITLE
[CMIS] Return the CDB status value for the caller to check the status…

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1237,7 +1237,7 @@ class CmisApi(XcvrApi):
         writelength = (writelength_raw + 1) * 8
         txt += 'Auto page support: %s\n' %autopaging_flag
         txt += 'Max write length: %d\n' %writelength
-        rpllen, rpl_chkcode, rpl = self.cdb.get_fw_management_features()
+        rpllen, rpl_chkcode, rpl = self.cdb.get_fw_management_features()['rpl']
         if self.cdb.cdb_chkcode(rpl) == rpl_chkcode:
             startLPLsize = rpl[2]
             txt += 'Start payload size %d\n' % startLPLsize
@@ -1282,7 +1282,7 @@ class CmisApi(XcvrApi):
             return {'status': False, 'info': "CDB Not supported", 'result': None}
 
         # get fw info (CMD 0100h)
-        rpllen, rpl_chkcode, rpl = self.cdb.get_fw_info()
+        rpllen, rpl_chkcode, rpl = self.cdb.get_fw_info()['rpl']
         # Interface NACK or timeout
         if (rpllen is None) or (rpl_chkcode is None):
             return {'status': False, 'info': "Interface fail", 'result': 0} # Return result 0 for distinguishing CDB is maybe in busy or failure.
@@ -1293,7 +1293,7 @@ class CmisApi(XcvrApi):
             logger.info(string)
             # Reset password for module using CMIS 4.0
             self.cdb.module_enter_password(0)
-            rpllen, rpl_chkcode, rpl = self.cdb.get_fw_info()
+            rpllen, rpl_chkcode, rpl = self.cdb.get_fw_info()['rpl']
 
         if self.cdb.cdb_chkcode(rpl) == rpl_chkcode:
             # Regiter 9Fh:136

--- a/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
@@ -155,13 +155,13 @@ class CmisCdbApi(XcvrApi):
         '''
         This QUERY Status command may be used to retrieve the password acceptance
         status and to perform a test of the CDB interface.
-        It returns the reply message of this CDB command 0000h.
+        It returns the status and reply message of this CDB command 0000h.
         '''
         cmd = bytearray(b'\x00\x00\x00\x00\x02\x00\x00\x00\x00\x10')
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
-        if (status != 0x1):
+        if status != 0x1:
             if status > 127:
                 txt = 'Query CDB status: Busy'
             else:
@@ -170,7 +170,8 @@ class CmisCdbApi(XcvrApi):
         else:
             txt = 'Query CDB status: Success'
         logger.info(txt)
-        return self.read_cdb()
+        rpl = self.read_cdb()
+        return {'status': status, 'rpl': rpl}
 
     # Enter password
     def module_enter_password(self, psw = 0x00001011):
@@ -199,13 +200,13 @@ class CmisCdbApi(XcvrApi):
     def get_module_feature(self):
         '''
         This command is used to query which CDB commands are supported.
-        It returns the reply message of this CDB command 0040h.
+        It returns the status and reply message of this CDB command 0040h.
         '''
         cmd = bytearray(b'\x00\x40\x00\x00\x00\x00\x00\x00')
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
-        if (status != 0x1):
+        if status != 0x1:
             if status > 127:
                 txt = 'Get module feature status: Busy'
             else:
@@ -214,19 +215,21 @@ class CmisCdbApi(XcvrApi):
         else:
             txt = 'Get module feature status: Success'
         logger.info(txt)
-        return self.read_cdb()
+
+        rpl = self.read_cdb()
+        return {'status': status, 'rpl': rpl}
 
     # Firmware Update Features Supported
     def get_fw_management_features(self):
         '''
         This command is used to query supported firmware update features
-        It returns the reply message of this CDB command 0041h.
+        It returns the status and reply message of this CDB command 0041h.
         '''
         cmd = bytearray(b'\x00\x41\x00\x00\x00\x00\x00\x00')
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
-        if (status != 0x1):
+        if status != 0x1:
             if status > 127:
                 txt = 'Get firmware management feature status: Busy'
             else:
@@ -235,20 +238,22 @@ class CmisCdbApi(XcvrApi):
         else:
             txt = 'Get firmware management feature status: Success'
         logger.info(txt)
-        return self.read_cdb()
+
+        rpl = self.read_cdb()
+        return {'status': status, 'rpl': rpl}
 
     # Get FW info
     def get_fw_info(self):
         '''
         This command returns the firmware versions and firmware default running
         images that reside in the module
-        It returns the reply message of this CDB command 0100h.
+        It returns the status and reply message of this CDB command 0100h.
         '''
         cmd = bytearray(b'\x01\x00\x00\x00\x00\x00\x00\x00')
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
-        if (status != 0x1):
+        if status != 0x1:
             if status > 127:
                 txt = 'Get firmware info status: Busy'
             else:
@@ -257,7 +262,9 @@ class CmisCdbApi(XcvrApi):
         else:
             txt = 'Get firmware info status: Success'
         logger.info(txt)
-        return self.read_cdb()
+
+        rpl = self.read_cdb()
+        return {'status': status, 'rpl': rpl}
 
     # Start FW download
     def start_fw_download(self, startLPLsize, header, imagesize):

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1158,14 +1158,22 @@ class TestCmis(object):
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
-        ((128, 1, [0] * 128),  {'status': True, 'info': "", 'result': 0}),
-        ((None, 1, [0] * 128),  {'status': False, 'info': "", 'result': 0}),
-        ((128, None, [0] * 128),  {'status': False, 'info': "", 'result': 0}),
-        ((128, 0, [0] * 128),  {'status': False, 'info': "", 'result': None}),
-        ((128, 1, [67, 3, 2, 2, 3, 183] + [0] * 104),  {'status': True, 'info': "", 'result': None}),
-        ((128, 1, [52, 3, 2, 2, 3, 183] + [0] * 104),  {'status': True, 'info': "", 'result': None}),
-        ((110, 1, [3, 3, 2, 2, 3, 183] + [0] * 104),  {'status': True, 'info': "", 'result': None}),
-        ((110, 1, [48, 3, 2, 2, 3, 183] + [0] * 104),  {'status': True, 'info': "", 'result': None}),
+        ({'status':1, 'rpl':(128, 1, [0] * 128)},
+         {'status': True, 'info': "", 'result': 0}),
+        ({'status':1, 'rpl':(None, 1, [0] * 128)},
+         {'status': False, 'info': "", 'result': 0}),
+        ({'status':1, 'rpl':(128, None, [0] * 128)},
+         {'status': False, 'info': "", 'result': 0}),
+        ({'status':1, 'rpl':(128, 0, [0] * 128)},
+         {'status': False, 'info': "", 'result': None}),
+        ({'status':1, 'rpl':(128, 1, [67, 3, 2, 2, 3, 183] + [0] * 104)},
+         {'status': True, 'info': "", 'result': None}),
+        ({'status':1, 'rpl':(128, 1, [52, 3, 2, 2, 3, 183] + [0] * 104)},
+         {'status': True, 'info': "", 'result': None}),
+        ({'status':1, 'rpl':(110, 1, [3, 3, 2, 2, 3, 183] + [0] * 104)},
+         {'status': True, 'info': "", 'result': None}),
+        ({'status':1, 'rpl':(110, 1, [48, 3, 2, 2, 3, 183] + [0] * 104)},
+         {'status': True, 'info': "", 'result': None}),
     ])
     def test_get_module_fw_info(self, mock_response, expected):
         self.api.cdb = MagicMock()
@@ -1178,7 +1186,8 @@ class TestCmis(object):
         self.api.cdb.get_fw_info = MagicMock()
         self.api.cdb.get_fw_info.return_value = mock_response
         result = self.api.get_module_fw_info()
-        if result['status'] == False: # Check 'result' when 'status' == False for distinguishing error type.
+        if result['status'] is False: # Check 'result' when 'status' == False
+                                      # for distinguishing error type.
             assert result['result'] == expected['result']
         assert result['status'] == expected['status']
 

--- a/tests/sonic_xcvr/test_cmisCDB.py
+++ b/tests/sonic_xcvr/test_cmisCDB.py
@@ -78,7 +78,7 @@ class TestCDB(object):
         self.api.cdb1_chkstatus.return_value = mock_response[0]
         self.api.read_cdb = MagicMock()
         self.api.read_cdb.return_value = mock_response[1]
-        result = self.api.query_cdb_status()
+        result = self.api.query_cdb_status()['rpl']
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
@@ -102,7 +102,7 @@ class TestCDB(object):
         self.api.cdb1_chkstatus.return_value = mock_response[0]
         self.api.read_cdb = MagicMock()
         self.api.read_cdb.return_value = mock_response[1]
-        result = self.api.get_module_feature()
+        result = self.api.get_module_feature()['rpl']
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
@@ -115,7 +115,7 @@ class TestCDB(object):
         self.api.cdb1_chkstatus.return_value = mock_response[0]
         self.api.read_cdb = MagicMock()
         self.api.read_cdb.return_value = mock_response[1]
-        result = self.api.get_fw_management_features()
+        result = self.api.get_fw_management_features()['rpl']
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
@@ -128,7 +128,7 @@ class TestCDB(object):
         self.api.cdb1_chkstatus.return_value = mock_response[0]
         self.api.read_cdb = MagicMock()
         self.api.read_cdb.return_value = mock_response[1]
-        result = self.api.get_fw_info()
+        result = self.api.get_fw_info()['rpl']
         assert result == expected
 
     @pytest.mark.parametrize("input_param, mock_response, expected", [


### PR DESCRIPTION

#### Description

This PR unifies all CDB API calls to return CDB status, allowing the caller to check the command status returned from the module and perform corresponding actions.

#### Motivation and Context
Modified the following CDB APIs to return a dictionary with CDB status as the first element and RPL result as the second element.

- query_cdb_status()
- get_module_feature()
- get_fw_management_features()
- get_fw_info()

The caller can first check the CDB status to ensure the command was processed successfully, then retrieve the data from the reply payload (RPL).

#### How Has This Been Tested?
Tested with Cisco8111 and Credo C1 cable
![image](https://github.com/user-attachments/assets/02237ed8-e0fc-40ae-bc69-8955c709d055)

